### PR TITLE
Adding a new macsec port id attribute to macsec flow attributes

### DIFF
--- a/inc/saimacsec.h
+++ b/inc/saimacsec.h
@@ -459,6 +459,15 @@ typedef enum _sai_macsec_flow_attr_t
     SAI_MACSEC_FLOW_ATTR_SC_LIST,
 
     /**
+     * @brief MACsec Port object id to associate a macsec flow with MACsec Port id
+     *
+     * @type sai_object_id_t
+     * @flags CREATE_AND_SET
+     * @objects SAI_OBJECT_TYPE_MACSEC_PORT
+     */
+    SAI_MACSEC_FLOW_ATTR_MACSEC_PORT_ID,
+
+    /**
      * @brief End of MACsec Flow attributes
      */
     SAI_MACSEC_FLOW_ATTR_END,


### PR DESCRIPTION
For multi-octal devices with same MDIO address requires a relation between macsec flow and macsec port id.